### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We need to install prerequisites to compile the kernel. On Ubuntu 20.04, this ca
    ```
    make -j32 bzImage
    make -j32 modules
-   make modules_install
+   make INSTALL_MOD_STRIP=1 modules_install
    make install
    ```
    The number 32 means the number of threads created for compilation. Set it to be the total number of cores of your system to reduce the compilation time. Type `lscpu | grep 'CPU(s)'` to see the total number of cores:


### PR DESCRIPTION
INSTALL_MOD_STRIP will reduce the size of generated boot image. Without the option, grub 2.0.4 will not bootable because the image is too large.